### PR TITLE
remove utf-8

### DIFF
--- a/lgw2/lgw2dev.yaml
+++ b/lgw2/lgw2dev.yaml
@@ -68,7 +68,7 @@ spec:
             value: 4G
           # JVM -Dオプション
           - name: JVM_DD_OPTS
-            value: "Paper.IgnoreJavaVersion:true,file.encoding:UTF-8"
+            value: "Paper.IgnoreJavaVersion:true"
           # yml内のCFG_なんとかを置き換えるためのもの
           - name: ENV_VARIABLE_PREFIX
             value: "CFG_"


### PR DESCRIPTION
lgw2devでIgnoreJavaVersionが効かないのを修正したい。
原因不明すぎるが、ここだけオプションが違うので変えてみる