### PR TITLE
life, lifepve java21

### DIFF
--- a/life/life.yaml
+++ b/life/life.yaml
@@ -29,12 +29,12 @@ spec:
         # 1.17.x ... 16-17 (16はサポート終了)
         # 1.18.x～1.20.4 ... 17
         # 1.20.5以降 ... 21
-        image: itzg/minecraft-server:java11
+        image: itzg/minecraft-server:java21
         workingDir: /data
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "24Gi"
+            memory: "20Gi"
         ports:
           - containerPort: 25565
         env:
@@ -85,7 +85,7 @@ spec:
             value: 1.15.2
           # 初期・最大メモリ
           - name: MEMORY
-            value: 24G
+            value: 20G
           # ホワイトリスト
           - name: ENABLE_WHITELIST
             value: "false"
@@ -94,7 +94,7 @@ spec:
             value: "log4j2Fix.loadReflectionUtil:true"
           # JVMオプション
           - name: JVM_OPTS
-            value: "-XX:+AlwaysPreTouch -javaagent:Log4j2Fix-1.0.4.jar=l -XX:MaxJavaStackTraceDepth=999999"
+            value: "-XX:+AlwaysPreTouch -javaagent:Log4j2Fix-1.0.4.jar=l -XX:MaxJavaStackTraceDepth=999999 -DPaper.IgnoreJavaVersion=true"
           # View Distance
           - name: VIEW_DISTANCE
             value: "8"

--- a/life/lifepve.yaml
+++ b/life/lifepve.yaml
@@ -29,7 +29,7 @@ spec:
         # 1.17.x ... 16-17 (16はサポート終了)
         # 1.18.x～1.20.4 ... 17
         # 1.20.5以降 ... 21
-        image: itzg/minecraft-server:java11
+        image: itzg/minecraft-server:java21
         workingDir: /data
         imagePullPolicy: Always
         resources:
@@ -97,7 +97,7 @@ spec:
             value: "log4j2Fix.loadReflectionUtil:true"
           # JVMオプション
           - name: JVM_OPTS
-            value: "-javaagent:Log4j2Fix-1.0.4.jar=l -DPaper.ignoreWorldDataVersion=true"
+            value: "-javaagent:Log4j2Fix-1.0.4.jar=l -DPaper.ignoreWorldDataVersion=true -DPaper.IgnoreJavaVersion=true"
           # yml内のCFG_なんとかを置き換えるためのもの
           - name: ENV_VARIABLE_PREFIX
             value: "CFG_"

--- a/life/lifepve1.yaml
+++ b/life/lifepve1.yaml
@@ -29,7 +29,7 @@ spec:
         # 1.17.x ... 16-17 (16はサポート終了)
         # 1.18.x～1.20.4 ... 17
         # 1.20.5以降 ... 21
-        image: itzg/minecraft-server:java11
+        image: itzg/minecraft-server:java21
         workingDir: /data
         imagePullPolicy: Always
         resources:
@@ -97,7 +97,7 @@ spec:
             value: "log4j2Fix.loadReflectionUtil:true"
           # JVMオプション
           - name: JVM_OPTS
-            value: "-javaagent:Log4j2Fix-1.0.4.jar=l -DPaper.ignoreWorldDataVersion=true"
+            value: "-javaagent:Log4j2Fix-1.0.4.jar=l -DPaper.ignoreWorldDataVersion=true -DPaper.IgnoreJavaVersion=true"
           # yml内のCFG_なんとかを置き換えるためのもの
           - name: ENV_VARIABLE_PREFIX
             value: "CFG_"

--- a/life/lifepve2.yaml
+++ b/life/lifepve2.yaml
@@ -29,7 +29,7 @@ spec:
         # 1.17.x ... 16-17 (16はサポート終了)
         # 1.18.x～1.20.4 ... 17
         # 1.20.5以降 ... 21
-        image: itzg/minecraft-server:java11
+        image: itzg/minecraft-server:java21
         workingDir: /data
         imagePullPolicy: Always
         resources:
@@ -97,7 +97,7 @@ spec:
             value: "log4j2Fix.loadReflectionUtil:true"
           # JVMオプション
           - name: JVM_OPTS
-            value: "-javaagent:Log4j2Fix-1.0.4.jar=l -DPaper.ignoreWorldDataVersion=true"
+            value: "-javaagent:Log4j2Fix-1.0.4.jar=l -DPaper.ignoreWorldDataVersion=true -DPaper.IgnoreJavaVersion=true"
           # yml内のCFG_なんとかを置き換えるためのもの
           - name: ENV_VARIABLE_PREFIX
             value: "CFG_"

--- a/life/liferesource.yaml
+++ b/life/liferesource.yaml
@@ -34,7 +34,7 @@ spec:
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "12Gi"
+            memory: "10Gi"
           limits:
             cpu: "6000m"
             memory: "14Gi"
@@ -91,7 +91,7 @@ spec:
             value: 1.15.2
           # 初期・最大メモリ
           - name: MEMORY
-            value: 12G # change to 8G after lifetown closes
+            value: 10G
           # ホワイトリスト
           - name: ENABLE_WHITELIST
             value: "false"


### PR DESCRIPTION
lifeとliferesourceに関して、メモリを過剰に割り当てていたため何GBか減らしています。
（自分の認識が正しければ）過剰に割り当てるとGCの一時停止時間が伸びる