### PR TITLE
chore: add RBAC for bonus server pod scaling

### DIFF
--- a/coasts/coasts.yaml
+++ b/coasts/coasts.yaml
@@ -19,6 +19,7 @@ spec:
         kuvel.azisaba.net/disable-load-balancer: "true"
         kuvel.azisaba.net/disable-name-suffix: "true"
     spec:
+      serviceAccountName: server-coasts
       containers:
         - name: server-coasts
           # Dockerイメージの指定
@@ -136,3 +137,35 @@ spec:
   ports:
     - port: 25565
       targetPort: 25565
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: server-coasts
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: server-coasts
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: server-coasts
+subjects:
+  - kind: ServiceAccount
+    name: server-coasts
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: server-coasts


### PR DESCRIPTION
ボーナスステージのPodをCoastsサーバーのプラグインから動的にスケールするために必要なServiceAccountを追加しました。