### PR TITLE
update: allow server-coasts to delete failed bonus stage pods

### DIFF
--- a/coasts/coasts.yaml
+++ b/coasts/coasts.yaml
@@ -163,7 +163,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "list", "patch", "update"]
+    verbs: ["delete", "get", "list", "patch", "update"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
接続に失敗したボーナスステージ用Podを削除するためにRBACにdeleteを追加。